### PR TITLE
Fix recipients query column name

### DIFF
--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -482,14 +482,14 @@ export async function getEmail(
       db,
       `SELECT a.address
        FROM recipients rc
-       JOIN addresses a ON rc.address_id = a.ROWID
+       JOIN addresses a ON rc.address = a.ROWID
        WHERE rc.message = ${safeInt(messageId)} AND rc.type = 0;`
     ),
     sqliteQuery(
       db,
       `SELECT a.address
        FROM recipients rc
-       JOIN addresses a ON rc.address_id = a.ROWID
+       JOIN addresses a ON rc.address = a.ROWID
        WHERE rc.message = ${safeInt(messageId)} AND rc.type = 1;`
     ),
   ]);


### PR DESCRIPTION
## Summary
- Fixed `mail_get_email` failing with `SQLite error: no such column: rc.address_id`
- The macOS Mail Envelope Index `recipients` table uses `address` (not `address_id`) as the FK to the `addresses` table
- Changed both TO and CC recipient queries to use `rc.address` instead of `rc.address_id`

## Test plan
- [x] Verified schema: `recipients` table has column `address`, not `address_id`
- [x] Tested query directly against Mail database — returns correct recipients
- [x] Build passes (`tsc` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)