### PR TITLE
Add missing preview field to EmailFullZ output schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ const EmailFullZ = z.object({
   cc: z.array(z.string()),
   mailbox: z.string(),
   account: z.string(),
+  preview: z.string(),
   attachments: z.array(AttachmentMetaZ).describe("Attachment metadata (filename, type, size). Content not included — metadata only."),
 });
 


### PR DESCRIPTION
## Summary
- `getEmail()` returns a `preview` field (inherited from `EmailSummary`) but the `EmailFullZ` Zod output schema didn't include it
- MCP strict output validation rejected every `mail_get_email` response with: `data must NOT have additional properties`
- Added `preview: z.string()` to `EmailFullZ`

## Test plan
- [x] Verified return object has exactly the properties declared in schema (no extra, no missing)
- [x] Build clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)