### PR TITLE
Fix HTML email: set both content and htmlContent

### DIFF
--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -687,19 +687,20 @@ export async function sendEmail(
        }`
     : "";
 
-  const bodyProp = htmlBody
-    ? `htmlContent: ${jxaString(htmlBody)}`
-    : `content: ${jxaString(body)}`;
+  const htmlBlock = htmlBody
+    ? `msg.htmlContent = ${jxaString(htmlBody)};`
+    : "";
 
   return executeJxaWrite(`
     const Mail = Application("Mail");
     ${acctSetup}
     const msg = Mail.OutgoingMessage({
       subject: ${jxaString(subject)},
-      ${bodyProp},
+      content: ${jxaString(body)},
       sender: acct.emailAddresses()[0]
     });
     Mail.outgoingMessages.push(msg);
+    ${htmlBlock}
     for (const addr of JSON.parse(${jxaString(JSON.stringify(to))})) {
       const r = Mail.ToRecipient({ address: addr });
       msg.toRecipients.push(r);
@@ -730,20 +731,21 @@ export async function createDraft(
        }`
     : "";
 
-  const bodyProp = htmlBody
-    ? `htmlContent: ${jxaString(htmlBody)}`
-    : `content: ${jxaString(body)}`;
+  const htmlBlock = htmlBody
+    ? `msg.htmlContent = ${jxaString(htmlBody)};`
+    : "";
 
   return executeJxaWrite(`
     const Mail = Application("Mail");
     ${acctSetup}
     const msg = Mail.OutgoingMessage({
       subject: ${jxaString(subject)},
-      ${bodyProp},
+      content: ${jxaString(body)},
       sender: acct.emailAddresses()[0],
       visible: true
     });
     Mail.outgoingMessages.push(msg);
+    ${htmlBlock}
     for (const addr of JSON.parse(${jxaString(JSON.stringify(to))})) {
       const r = Mail.ToRecipient({ address: addr });
       msg.toRecipients.push(r);
@@ -770,9 +772,9 @@ export async function replyTo(
 
   const acctSetup = `const acct = Mail.accounts.byName(${jxaString(account)});`;
 
-  const replyBodyBlock = htmlBody
+  const replyHtmlBlock = htmlBody
     ? `reply.htmlContent = ${jxaString(htmlBody)};`
-    : `reply.content = ${jxaString(body)} + "\\n\\n" + reply.content();`;
+    : "";
 
   return executeJxaWrite(`
     const Mail = Application("Mail");
@@ -784,7 +786,8 @@ export async function replyTo(
     const msg = mb.messages[idx];
     const reply = msg.reply({ replyToAll: ${Boolean(replyAll)}, openingWindow: ${!Boolean(send)} });
     if (reply) {
-      ${replyBodyBlock}
+      reply.content = ${jxaString(body)} + "\\n\\n" + reply.content();
+      ${replyHtmlBlock}
       ${send ? "reply.send();" : ""}
     }
     JSON.stringify({
@@ -811,11 +814,12 @@ export async function forwardMessage(
 
   const acctSetup = `const acct = Mail.accounts.byName(${jxaString(account)});`;
 
-  const fwdBodyBlock = htmlBody
+  const fwdContentBlock = body
+    ? `fwd.content = ${jxaString(body)} + "\\n\\n" + fwd.content();`
+    : "";
+  const fwdHtmlBlock = htmlBody
     ? `fwd.htmlContent = ${jxaString(htmlBody)};`
-    : body
-      ? `fwd.content = ${jxaString(body)} + "\\n\\n" + fwd.content();`
-      : "";
+    : "";
 
   return executeJxaWrite(`
     const Mail = Application("Mail");
@@ -831,7 +835,8 @@ export async function forwardMessage(
         const r = Mail.ToRecipient({ address: addr });
         fwd.toRecipients.push(r);
       }
-      ${fwdBodyBlock}
+      ${fwdContentBlock}
+      ${fwdHtmlBlock}
       ${send ? "fwd.send();" : ""}
     }
     JSON.stringify({


### PR DESCRIPTION
## Summary
- Apple Mail requires `content` (plain text) on every outgoing message — without it shows "no content"
- Now always sets `content` in constructor, then sets `htmlContent` afterward when `htmlBody` is provided
- Both properties present before `send()` gives proper multipart/alternative email (HTML with plain text fallback)
- Applied to all four tools: send, draft, reply, forward

## Test plan
- [x] Build clean, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)