### PR TITLE
Fix sender address fallback for HTML emails

### DIFF
--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -702,8 +702,12 @@ async function sendHtmlViaAppleScript(opts: {
   const script = `
 tell application "Mail"
     ${acctLine}
-    set senderAddr to first item of (email addresses of acct)
-    set newMsg to make new outgoing message with properties {subject:${asString(opts.subject)}, content:${asString(opts.body)}, sender:senderAddr, visible:${visible}}
+    try
+        set senderAddr to first item of (email addresses of acct)
+        set newMsg to make new outgoing message with properties {subject:${asString(opts.subject)}, content:${asString(opts.body)}, sender:senderAddr, visible:${visible}}
+    on error
+        set newMsg to make new outgoing message with properties {subject:${asString(opts.subject)}, content:${asString(opts.body)}, visible:${visible}}
+    end try
     tell newMsg
         ${toRecipients}
         ${ccRecipients}


### PR DESCRIPTION
## Summary
- EWS accounts fail on `email addresses of acct` in AppleScript
- Added try/catch: falls back to creating message without explicit sender
- Mail.app uses its default sender when not specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)