### PR TITLE
Fix HTML file reading in AppleScript

### DIFF
--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -708,9 +708,7 @@ async function sendHtmlViaAppleScript(opts: {
   const htmlFile = join(tmpdir(), `macos-mcp-html-${id}.html`);
   const scriptFile = join(tmpdir(), `macos-mcp-script-${id}.scpt`);
 
-  const script = `
-set htmlFile to POSIX file ${asString(htmlFile)}
-set htmlContent to read htmlFile as «class utf8»
+  const script = `set htmlContent to do shell script "/bin/cat " & quoted form of ${asString(htmlFile)}
 
 tell application "Mail"
     ${acctLine}


### PR DESCRIPTION
## Summary
- `read file as «class utf8»` fails with error -4960 when run from a script file (guillemet encoding issue)
- Replaced with `do shell script "/bin/cat " & quoted form of path` which works reliably
- Confirmed: HTML content properly applied via `set html content of` + file reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)