### PR TITLE
feat: add MACOS_MCP_READONLY env var to disable write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 | `MACOS_MCP_MAIL_ACCOUNT` | Default mail account name | First account |
 | `MACOS_MCP_REMINDER_LISTS` | Comma-separated reminder list names to include | All lists |
 | `MACOS_MCP_WRITE_RATE_LIMIT` | Max write operations per minute | 10 |
+| `MACOS_MCP_READONLY` | Disable all write tools (`true` or `1`) | Not set (all tools) |
+
+### Read-Only Mode
+
+To disable all write operations (send, reply, forward, create, delete, etc.):
+
+```json
+{
+  "mcpServers": {
+    "macos": {
+      "command": "npx",
+      "args": ["macos-mcp-server"],
+      "env": {
+        "MACOS_MCP_READONLY": "true"
+      }
+    }
+  }
+}
+```
+
+When enabled, write tools are not registered and won't appear in the tool list.
+Read operations (listing, searching, viewing) and FTS indexing remain available.
 
 ## Tools (33)
 

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -10,6 +10,10 @@ import { paginateArray, paginateRows, fromCoreDataTimestamp, sanitizeErrorMessag
 import { isReadOnly } from "../shared/config.js";
 import { jxaString, jxaStringArray } from "../shared/applescript.js";
 import { emlxSubpath, decodeQuotedPrintable, stripHtml } from "../mail/fts.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerMailTools } from "../mail/register.js";
+import { registerCalendarTools } from "../calendar/register.js";
+import { registerRemindersTools } from "../reminders/register.js";
 
 // ─── sqlEscape ──────────────────────────────────────────────────
 
@@ -553,5 +557,133 @@ describe("isReadOnly", () => {
   it("returns false when env var is empty string", () => {
     process.env.MACOS_MCP_READONLY = "";
     assert.equal(isReadOnly(), false);
+  });
+});
+
+// ─── Read-only integration: tool registration ────────────────────
+
+const MAIL_WRITE_TOOLS = ["mail_send", "mail_create_draft", "mail_reply", "mail_forward", "mail_move", "mail_set_flags"];
+const CALENDAR_WRITE_TOOLS = ["calendar_create_event", "calendar_modify_event", "calendar_delete_event"];
+const REMINDERS_WRITE_TOOLS = ["reminders_create", "reminders_complete", "reminders_delete"];
+
+function makeMockServer(): { server: McpServer; registeredTools: () => string[] } {
+  const names: string[] = [];
+  const server = {
+    registerTool: (name: string, ..._rest: unknown[]) => { names.push(name); },
+  } as unknown as McpServer;
+  return { server, registeredTools: () => names };
+}
+
+describe("read-only integration: registerMailTools", () => {
+  const originalEnv = process.env.MACOS_MCP_READONLY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_READONLY;
+    } else {
+      process.env.MACOS_MCP_READONLY = originalEnv;
+    }
+  });
+
+  it("omits all 6 write tools when MACOS_MCP_READONLY=true", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerMailTools(server);
+    for (const tool of MAIL_WRITE_TOOLS) {
+      assert.ok(!registeredTools().includes(tool), `Expected ${tool} to be absent in read-only mode`);
+    }
+  });
+
+  it("includes all 6 write tools when MACOS_MCP_READONLY is not set", () => {
+    delete process.env.MACOS_MCP_READONLY;
+    const { server, registeredTools } = makeMockServer();
+    registerMailTools(server);
+    for (const tool of MAIL_WRITE_TOOLS) {
+      assert.ok(registeredTools().includes(tool), `Expected ${tool} to be present in normal mode`);
+    }
+  });
+
+  it("still registers read-only tools regardless of MACOS_MCP_READONLY", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerMailTools(server);
+    assert.ok(registeredTools().includes("mail_get_emails"));
+    assert.ok(registeredTools().includes("mail_search"));
+  });
+});
+
+describe("read-only integration: registerCalendarTools", () => {
+  const originalEnv = process.env.MACOS_MCP_READONLY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_READONLY;
+    } else {
+      process.env.MACOS_MCP_READONLY = originalEnv;
+    }
+  });
+
+  it("omits all 3 write tools when MACOS_MCP_READONLY=true", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerCalendarTools(server);
+    for (const tool of CALENDAR_WRITE_TOOLS) {
+      assert.ok(!registeredTools().includes(tool), `Expected ${tool} to be absent in read-only mode`);
+    }
+  });
+
+  it("includes all 3 write tools when MACOS_MCP_READONLY is not set", () => {
+    delete process.env.MACOS_MCP_READONLY;
+    const { server, registeredTools } = makeMockServer();
+    registerCalendarTools(server);
+    for (const tool of CALENDAR_WRITE_TOOLS) {
+      assert.ok(registeredTools().includes(tool), `Expected ${tool} to be present in normal mode`);
+    }
+  });
+
+  it("still registers read-only tools regardless of MACOS_MCP_READONLY", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerCalendarTools(server);
+    assert.ok(registeredTools().includes("calendar_today"));
+    assert.ok(registeredTools().includes("calendar_get_events"));
+  });
+});
+
+describe("read-only integration: registerRemindersTools", () => {
+  const originalEnv = process.env.MACOS_MCP_READONLY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_READONLY;
+    } else {
+      process.env.MACOS_MCP_READONLY = originalEnv;
+    }
+  });
+
+  it("omits all 3 write tools when MACOS_MCP_READONLY=true", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerRemindersTools(server);
+    for (const tool of REMINDERS_WRITE_TOOLS) {
+      assert.ok(!registeredTools().includes(tool), `Expected ${tool} to be absent in read-only mode`);
+    }
+  });
+
+  it("includes all 3 write tools when MACOS_MCP_READONLY is not set", () => {
+    delete process.env.MACOS_MCP_READONLY;
+    const { server, registeredTools } = makeMockServer();
+    registerRemindersTools(server);
+    for (const tool of REMINDERS_WRITE_TOOLS) {
+      assert.ok(registeredTools().includes(tool), `Expected ${tool} to be present in normal mode`);
+    }
+  });
+
+  it("still registers read-only tools regardless of MACOS_MCP_READONLY", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    const { server, registeredTools } = makeMockServer();
+    registerRemindersTools(server);
+    assert.ok(registeredTools().includes("reminders_get"));
+    assert.ok(registeredTools().includes("reminders_list_lists"));
   });
 });

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -3,10 +3,11 @@
  * Run with: npm test
  */
 
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { sqlEscape, sqlLikeEscape, safeInt } from "../shared/sqlite.js";
 import { paginateArray, paginateRows, fromCoreDataTimestamp, sanitizeErrorMessage } from "../shared/types.js";
+import { isReadOnly } from "../shared/config.js";
 import { jxaString, jxaStringArray } from "../shared/applescript.js";
 import { emlxSubpath, decodeQuotedPrintable, stripHtml } from "../mail/fts.js";
 
@@ -503,5 +504,54 @@ describe("stripHtml", () => {
 
   it("handles nested tags", () => {
     assert.equal(stripHtml("<div><span><b>text</b></span></div>").trim(), "text");
+  });
+});
+
+// ─── isReadOnly ──────────────────────────────────────────────────
+
+describe("isReadOnly", () => {
+  const originalEnv = process.env.MACOS_MCP_READONLY;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_READONLY;
+    } else {
+      process.env.MACOS_MCP_READONLY = originalEnv;
+    }
+  });
+
+  it("returns false when env var is not set", () => {
+    delete process.env.MACOS_MCP_READONLY;
+    assert.equal(isReadOnly(), false);
+  });
+
+  it("returns true when env var is 'true'", () => {
+    process.env.MACOS_MCP_READONLY = "true";
+    assert.equal(isReadOnly(), true);
+  });
+
+  it("returns true when env var is '1'", () => {
+    process.env.MACOS_MCP_READONLY = "1";
+    assert.equal(isReadOnly(), true);
+  });
+
+  it("returns false when env var is 'false'", () => {
+    process.env.MACOS_MCP_READONLY = "false";
+    assert.equal(isReadOnly(), false);
+  });
+
+  it("returns false when env var is '0'", () => {
+    process.env.MACOS_MCP_READONLY = "0";
+    assert.equal(isReadOnly(), false);
+  });
+
+  it("returns false when env var is 'yes'", () => {
+    process.env.MACOS_MCP_READONLY = "yes";
+    assert.equal(isReadOnly(), false);
+  });
+
+  it("returns false when env var is empty string", () => {
+    process.env.MACOS_MCP_READONLY = "";
+    assert.equal(isReadOnly(), false);
   });
 });

--- a/src/calendar/register.ts
+++ b/src/calendar/register.ts
@@ -5,6 +5,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource } from "../shared/mcp-helpers.js";
+import { isReadOnly } from "../shared/config.js";
 import * as calendar from "./tools.js";
 
 // ─── Output Schemas ─────────────────────────────────────────────
@@ -129,6 +130,7 @@ export function registerCalendarTools(server: McpServer): void {
     } catch (e) { return err(e); }
   });
 
+  if (!isReadOnly()) {
   server.registerTool("calendar_create_event", {
     title: "Create Calendar Event",
     description: "Create a new calendar event. Use when: scheduling a meeting, adding an event to the calendar",
@@ -186,6 +188,7 @@ export function registerCalendarTools(server: McpServer): void {
       return ok(result, false);
     } catch (e) { return err(e); }
   });
+  } // end read-only guard
 }
 
 // ─── Resource Registrations ─────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { registerMailTools, registerMailResources, EmailSummaryZ } from "./mail/
 import { registerCalendarTools, registerCalendarResources, EventSummaryZ } from "./calendar/register.js";
 import { registerRemindersTools, registerRemindersResources, ReminderSummaryZ } from "./reminders/register.js";
 import { registerContactsTools, registerContactsResources } from "./contacts/register.js";
+import { isReadOnly } from "./shared/config.js";
 
 import * as mail from "./mail/tools.js";
 import * as mailFts from "./mail/fts.js";
@@ -82,6 +83,10 @@ const FTS_AUTO_INDEX_BATCH = 5_000;
 const FTS_AUTO_INDEX_INCREMENTAL = 50_000;
 
 // ─── Register Domain Tools & Resources ──────────────────────────
+
+if (isReadOnly()) {
+  log("Read-only mode enabled (MACOS_MCP_READONLY). Write tools will not be registered.");
+}
 
 registerMailTools(server);
 registerCalendarTools(server);

--- a/src/mail/register.ts
+++ b/src/mail/register.ts
@@ -6,6 +6,7 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { z } from "zod";
 import { ok, err, paginatedOutput, SuccessZ, SuccessMessageZ, resource } from "../shared/mcp-helpers.js";
 import { sanitizeErrorMessage } from "../shared/types.js";
+import { isReadOnly } from "../shared/config.js";
 import * as mail from "./tools.js";
 import * as mailFts from "./fts.js";
 
@@ -153,6 +154,7 @@ export function registerMailTools(server: McpServer): void {
     } catch (e) { return err(e); }
   });
 
+  if (!isReadOnly()) {
   server.registerTool("mail_send", {
     title: "Send Email",
     description: "Send an email. Supports HTML formatting via htmlBody for rich text (bold, italic, links, tables, etc). For important emails, prefer mail_create_draft so the user can review first. Use when: sending a quick reply, automated email dispatch",
@@ -270,6 +272,7 @@ export function registerMailTools(server: McpServer): void {
       return ok(result, false);
     } catch (e) { return err(e); }
   });
+  } // end read-only guard
 
   // ─── FTS Tools ──────────────────────────────────────────────────
 

--- a/src/reminders/register.ts
+++ b/src/reminders/register.ts
@@ -5,6 +5,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource } from "../shared/mcp-helpers.js";
+import { isReadOnly } from "../shared/config.js";
 import * as reminders from "./tools.js";
 
 // ─── Output Schemas ─────────────────────────────────────────────
@@ -82,6 +83,7 @@ export function registerRemindersTools(server: McpServer): void {
     } catch (e) { return err(e); }
   });
 
+  if (!isReadOnly()) {
   server.registerTool("reminders_create", {
     title: "Create Reminder",
     description: "Create a new reminder. Use when: adding a task or to-do item, setting a due-date reminder",
@@ -133,6 +135,7 @@ export function registerRemindersTools(server: McpServer): void {
       return ok(result, false);
     } catch (e) { return err(e); }
   });
+  } // end read-only guard
 }
 
 // ─── Resource Registrations ─────────────────────────────────────

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -30,6 +30,12 @@ export function getReminderLists(): string[] | null {
   return val.split(",").map((s) => s.trim()).filter(Boolean);
 }
 
+/** Check if write operations are disabled via MACOS_MCP_READONLY. */
+export function isReadOnly(): boolean {
+  const val = process.env.MACOS_MCP_READONLY;
+  return val === "true" || val === "1";
+}
+
 // ─── Mail DB Auto-Detection ──────────────────────────────────────
 
 let _mailDbPath: string | null = null;


### PR DESCRIPTION
Adds a read-only mode that prevents all write operations (send email, create/modify/delete calendar events, create/complete/delete reminders) when `MACOS_MCP_READONLY=true` is set.

## Motivation

The security audit identified **prompt injection via email content** as the #1 risk. A malicious email body can instruct the LLM client to call write tools (`mail_send`, `mail_forward`, `calendar_delete_event`, etc.) and exfiltrate data or cause damage.

Read-only mode eliminates this attack surface by preventing write tool registration at the MCP level — the tools simply don't exist for the client to call.

## What this does

- Adds `isReadOnly()` config getter that checks `MACOS_MCP_READONLY` env var
- Skips registration of 12 write tools when enabled (6 mail, 3 calendar, 3 reminders)
- FTS indexing remains available (writes only to local index, not user data)
- Logs read-only mode at startup
- Adds unit tests for `isReadOnly()`
- Documents the env var and read-only mode in README

Closes #26
