### PR TITLE
feat: add MACOS_MCP_ALLOWED_RECIPIENTS env var to restrict mail_send recipients

### DIFF
--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -3,12 +3,13 @@
  * Run with: npm test
  */
 
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { sqlEscape, sqlLikeEscape, safeInt } from "../shared/sqlite.js";
 import { paginateArray, paginateRows, fromCoreDataTimestamp, sanitizeErrorMessage } from "../shared/types.js";
 import { jxaString, jxaStringArray } from "../shared/applescript.js";
 import { emlxSubpath, decodeQuotedPrintable, stripHtml } from "../mail/fts.js";
+import { matchesAllowlist, findBlockedRecipient } from "../shared/config.js";
 
 // ─── sqlEscape ──────────────────────────────────────────────────
 
@@ -503,5 +504,75 @@ describe("stripHtml", () => {
 
   it("handles nested tags", () => {
     assert.equal(stripHtml("<div><span><b>text</b></span></div>").trim(), "text");
+  });
+});
+
+// ─── matchesAllowlist ─────────────────────────────────────────────
+
+describe("matchesAllowlist", () => {
+  it("matches exact address", () => {
+    assert.ok(matchesAllowlist("alice@example.com", ["alice@example.com"]));
+  });
+
+  it("rejects address not in list", () => {
+    assert.ok(!matchesAllowlist("bob@example.com", ["alice@example.com"]));
+  });
+
+  it("matches wildcard domain pattern", () => {
+    assert.ok(matchesAllowlist("anyone@company.com", ["*@company.com"]));
+  });
+
+  it("rejects address outside wildcard domain", () => {
+    assert.ok(!matchesAllowlist("anyone@evil.com", ["*@company.com"]));
+  });
+
+  it("matching is case-insensitive", () => {
+    assert.ok(matchesAllowlist("Alice@COMPANY.COM", ["*@company.com"]));
+  });
+
+  it("matches when one of multiple patterns applies", () => {
+    assert.ok(matchesAllowlist("guest@external.com", ["*@company.com", "guest@external.com"]));
+  });
+
+  it("wildcard does not span dots by accident — domain must still match fully", () => {
+    assert.ok(!matchesAllowlist("alice@evilcompany.com", ["*@company.com"]));
+  });
+});
+
+// ─── findBlockedRecipient ─────────────────────────────────────────
+
+describe("findBlockedRecipient", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.MACOS_MCP_ALLOWED_RECIPIENTS;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.MACOS_MCP_ALLOWED_RECIPIENTS;
+    } else {
+      process.env.MACOS_MCP_ALLOWED_RECIPIENTS = savedEnv;
+    }
+  });
+
+  it("returns null when env var is not set", () => {
+    delete process.env.MACOS_MCP_ALLOWED_RECIPIENTS;
+    assert.equal(findBlockedRecipient(["anyone@anywhere.com"]), null);
+  });
+
+  it("returns null when all recipients match the allowlist", () => {
+    process.env.MACOS_MCP_ALLOWED_RECIPIENTS = "*@company.com";
+    assert.equal(findBlockedRecipient(["alice@company.com", "bob@company.com"]), null);
+  });
+
+  it("returns the first blocked address", () => {
+    process.env.MACOS_MCP_ALLOWED_RECIPIENTS = "*@company.com";
+    assert.equal(findBlockedRecipient(["alice@company.com", "attacker@evil.com"]), "attacker@evil.com");
+  });
+
+  it("rejects with multiple patterns when none match", () => {
+    process.env.MACOS_MCP_ALLOWED_RECIPIENTS = "*@company.com,trusted@partner.com";
+    assert.equal(findBlockedRecipient(["unknown@other.com"]), "unknown@other.com");
   });
 });

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -37,6 +37,7 @@ import {
   getMailDbPath,
   getMailAccountMap,
   mailboxUrlFilter,
+  findBlockedRecipient,
 } from "../shared/config.js";
 import { PaginatedResult, paginateRows, sanitizeErrorMessage } from "../shared/types.js";
 import {
@@ -750,6 +751,12 @@ export async function sendEmail(
   account?: string,
   htmlBody?: string
 ): Promise<{ success: boolean; message: string }> {
+  const allRecipients = [...to, ...(cc ?? []), ...(bcc ?? [])];
+  const blocked = findBlockedRecipient(allRecipients);
+  if (blocked) {
+    return { success: false, message: `Recipient not allowed by MACOS_MCP_ALLOWED_RECIPIENTS: ${blocked}` };
+  }
+
   // Use iCloud SMTP for HTML emails (Apple Mail's scripting strips HTML from outgoing)
   if (htmlBody) {
     return sendHtmlViaSmtp({ to, subject, body, htmlBody, cc, bcc });

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -7,6 +7,9 @@
  *
  * MACOS_MCP_MAIL_ACCOUNT: Default mail account name.
  * MACOS_MCP_REMINDER_LISTS: Comma-separated list of reminder lists to include.
+ * MACOS_MCP_ALLOWED_RECIPIENTS: Comma-separated list of allowed recipient patterns for mail_send.
+ *   Supports wildcard (*) matching. If set, any recipient not matching causes an error.
+ *   Example: "*@yourcompany.com,trusted@example.com"
  */
 
 import { homedir } from "node:os";
@@ -28,6 +31,45 @@ export function getReminderLists(): string[] | null {
   const val = process.env.MACOS_MCP_REMINDER_LISTS;
   if (!val) return null;
   return val.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// ─── Recipient Allowlist ─────────────────────────────────────────
+
+/**
+ * Returns the list of allowed recipient patterns from MACOS_MCP_ALLOWED_RECIPIENTS,
+ * or null if the env var is not set (meaning all recipients are allowed).
+ */
+export function getAllowedRecipients(): string[] | null {
+  const val = process.env.MACOS_MCP_ALLOWED_RECIPIENTS;
+  if (!val) return null;
+  return val.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+}
+
+/**
+ * Returns true if the given email address matches at least one pattern in the allowlist.
+ * Patterns support a single leading wildcard: `*@domain.com`.
+ * Matching is case-insensitive.
+ */
+export function matchesAllowlist(address: string, patterns: string[]): boolean {
+  const addr = address.trim().toLowerCase();
+  return patterns.some((pattern) => {
+    if (pattern.includes("*")) {
+      // Escape all regex metacharacters except *, then replace * with .*
+      const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+      return new RegExp(`^${escaped}$`).test(addr);
+    }
+    return addr === pattern;
+  });
+}
+
+/**
+ * Validates a list of recipient addresses against the allowlist.
+ * Returns the first rejected address, or null if all pass (or no allowlist is set).
+ */
+export function findBlockedRecipient(addresses: string[]): string | null {
+  const patterns = getAllowedRecipients();
+  if (!patterns) return null;
+  return addresses.find((addr) => !matchesAllowlist(addr, patterns)) ?? null;
 }
 
 // ─── Mail DB Auto-Detection ──────────────────────────────────────


### PR DESCRIPTION
Closes #28

## Changes

- `src/shared/config.ts` — adds `getAllowedRecipients()`, `matchesAllowlist()`, and `findBlockedRecipient()` following the same env-var pattern as `MACOS_MCP_READONLY` (#26)
- `src/mail/tools.ts` — `sendEmail()` validates all recipients (`to`, `cc`, `bcc`) against the allowlist before sending; returns a structured error on the first blocked address
- `src/__tests__/shared.test.ts` — 11 new unit tests covering exact match, wildcard domains, case-insensitivity, domain boundary safety, and `findBlockedRecipient` with/without env var set

## Usage

```
MACOS_MCP_ALLOWED_RECIPIENTS="*@yourcompany.com,trusted@partner.com"
```

If any recipient doesn't match, `mail_send` returns `{ success: false, message: "Recipient not allowed by MACOS_MCP_ALLOWED_RECIPIENTS: ..." }` without sending.
