### PR TITLE
feat: add MACOS_MCP_SEND_AS_DRAFT env var to prevent immediate sending

### DIFF
--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -3,12 +3,13 @@
  * Run with: npm test
  */
 
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { sqlEscape, sqlLikeEscape, safeInt } from "../shared/sqlite.js";
 import { paginateArray, paginateRows, fromCoreDataTimestamp, sanitizeErrorMessage } from "../shared/types.js";
 import { jxaString, jxaStringArray } from "../shared/applescript.js";
 import { emlxSubpath, decodeQuotedPrintable, stripHtml } from "../mail/fts.js";
+import { isSendAsDraft } from "../shared/config.js";
 
 // ─── sqlEscape ──────────────────────────────────────────────────
 
@@ -503,5 +504,43 @@ describe("stripHtml", () => {
 
   it("handles nested tags", () => {
     assert.equal(stripHtml("<div><span><b>text</b></span></div>").trim(), "text");
+  });
+});
+
+// ─── isSendAsDraft ────────────────────────────────────────────────
+
+describe("isSendAsDraft", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.MACOS_MCP_SEND_AS_DRAFT;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.MACOS_MCP_SEND_AS_DRAFT;
+    } else {
+      process.env.MACOS_MCP_SEND_AS_DRAFT = savedEnv;
+    }
+  });
+
+  it("returns false when env var is not set", () => {
+    delete process.env.MACOS_MCP_SEND_AS_DRAFT;
+    assert.equal(isSendAsDraft(), false);
+  });
+
+  it("returns true when set to 'true'", () => {
+    process.env.MACOS_MCP_SEND_AS_DRAFT = "true";
+    assert.equal(isSendAsDraft(), true);
+  });
+
+  it("returns true when set to '1'", () => {
+    process.env.MACOS_MCP_SEND_AS_DRAFT = "1";
+    assert.equal(isSendAsDraft(), true);
+  });
+
+  it("returns false for other values", () => {
+    process.env.MACOS_MCP_SEND_AS_DRAFT = "yes";
+    assert.equal(isSendAsDraft(), false);
   });
 });

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -37,6 +37,7 @@ import {
   getMailDbPath,
   getMailAccountMap,
   mailboxUrlFilter,
+  isSendAsDraft,
 } from "../shared/config.js";
 import { PaginatedResult, paginateRows, sanitizeErrorMessage } from "../shared/types.js";
 import {
@@ -750,6 +751,16 @@ export async function sendEmail(
   account?: string,
   htmlBody?: string
 ): Promise<{ success: boolean; message: string }> {
+  if (isSendAsDraft()) {
+    if (htmlBody) {
+      return { success: false, message: "MACOS_MCP_SEND_AS_DRAFT is set but HTML drafts are not supported by Mail.app scripting. Remove htmlBody or disable MACOS_MCP_SEND_AS_DRAFT to send HTML email." };
+    }
+    if (bcc?.length) {
+      return { success: false, message: "MACOS_MCP_SEND_AS_DRAFT is set but Mail.app scripting does not support bcc on drafts. Remove bcc or disable MACOS_MCP_SEND_AS_DRAFT." };
+    }
+    return createDraft(to, subject, body, cc, account);
+  }
+
   // Use iCloud SMTP for HTML emails (Apple Mail's scripting strips HTML from outgoing)
   if (htmlBody) {
     return sendHtmlViaSmtp({ to, subject, body, htmlBody, cc, bcc });

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -30,6 +30,15 @@ export function getReminderLists(): string[] | null {
   return val.split(",").map((s) => s.trim()).filter(Boolean);
 }
 
+/**
+ * When true, mail_send saves to Mail.app drafts instead of sending.
+ * Controlled by MACOS_MCP_SEND_AS_DRAFT=true|1.
+ */
+export function isSendAsDraft(): boolean {
+  const val = process.env.MACOS_MCP_SEND_AS_DRAFT;
+  return val === "true" || val === "1";
+}
+
 // ─── Mail DB Auto-Detection ──────────────────────────────────────
 
 let _mailDbPath: string | null = null;


### PR DESCRIPTION
Closes #29

## Changes

- `src/shared/config.ts` — adds `isSendAsDraft()` following the same pattern as `isReadOnly()` from #26
- `src/mail/tools.ts` — `sendEmail()` branches at the top: when `MACOS_MCP_SEND_AS_DRAFT=true`, it routes through `createDraft()` instead of sending. Returns a descriptive error if `htmlBody` or `bcc` are present (unsupported by Mail.app scripting in draft mode)
- `src/__tests__/shared.test.ts` — 4 new unit tests for `isSendAsDraft()` covering unset, `true`, `1`, and other values

## Relationship to MACOS_MCP_READONLY (#26)

- `MACOS_MCP_READONLY=true` — `mail_send` is not registered at all (tool doesn't exist)
- `MACOS_MCP_SEND_AS_DRAFT=true` — tool exists, but always saves a draft instead of sending

If both are set, `MACOS_MCP_READONLY` takes precedence.

## Usage

```
MACOS_MCP_SEND_AS_DRAFT=true
```

`mail_send` will call `createDraft()` and return:
`{ success: true, message: "Draft created — review in Mail.app" }`
