### PR TITLE
security: extend recipient allowlist and draft-mode to mail_reply and mail_forward

### DIFF
--- a/src/mail/register.ts
+++ b/src/mail/register.ts
@@ -198,7 +198,7 @@ export function registerMailTools(server: McpServer): void {
 
   server.registerTool("mail_reply", {
     title: "Reply to Email",
-    description: "Reply to an email (plain text only). Set send=false to save as draft for review. Use when: responding to a conversation, following up on a thread",
+    description: "Reply to an email (plain text only). Set send=false to save as draft for review. Honours MACOS_MCP_SEND_AS_DRAFT (forces draft mode). Use when: responding to a conversation, following up on a thread",
     inputSchema: z.object({
       messageId: z.number().describe("Email ID to reply to"),
       body: z.string().max(100000).describe("Plain text reply body"),
@@ -218,7 +218,7 @@ export function registerMailTools(server: McpServer): void {
 
   server.registerTool("mail_forward", {
     title: "Forward Email",
-    description: "Forward an email (plain text only). Set send=false to save as draft for review. Mailbox and account are auto-resolved from the message ID if not provided. Use when: sharing an email with someone else, delegating a message",
+    description: "Forward an email (plain text only). Set send=false to save as draft for review. Validates recipients against MACOS_MCP_ALLOWED_RECIPIENTS and honours MACOS_MCP_SEND_AS_DRAFT (forces draft mode). Mailbox and account are auto-resolved from the message ID if not provided. Use when: sharing an email with someone else, delegating a message",
     inputSchema: z.object({
       messageId: z.number().describe("Email ID to forward"),
       to: z.array(z.string().email("Invalid email address")).min(1, "At least one recipient required").describe("Forward to these addresses"),

--- a/src/mail/tools.ts
+++ b/src/mail/tools.ts
@@ -870,6 +870,11 @@ export async function replyTo(
   mailbox?: string,
   account?: string
 ): Promise<{ success: boolean; message: string }> {
+  // Honour MACOS_MCP_SEND_AS_DRAFT — force draft mode
+  if (isSendAsDraft()) {
+    send = false;
+  }
+
   if (!mailbox || !account) {
     const loc = await resolveMessageLocation(messageId);
     mailbox = mailbox || loc.mailboxName;
@@ -906,6 +911,17 @@ export async function forwardMessage(
   mailbox?: string,
   account?: string
 ): Promise<{ success: boolean; message: string }> {
+  // Validate recipients against allowlist
+  const blocked = findBlockedRecipient(to);
+  if (blocked) {
+    return { success: false, message: `Recipient not allowed by MACOS_MCP_ALLOWED_RECIPIENTS: ${blocked}` };
+  }
+
+  // Honour MACOS_MCP_SEND_AS_DRAFT — force draft mode
+  if (isSendAsDraft()) {
+    send = false;
+  }
+
   if (!mailbox || !account) {
     const loc = await resolveMessageLocation(messageId);
     mailbox = mailbox || loc.mailboxName;

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -7,7 +7,7 @@
  *
  * MACOS_MCP_MAIL_ACCOUNT: Default mail account name.
  * MACOS_MCP_REMINDER_LISTS: Comma-separated list of reminder lists to include.
- * MACOS_MCP_ALLOWED_RECIPIENTS: Comma-separated list of allowed recipient patterns for mail_send.
+ * MACOS_MCP_ALLOWED_RECIPIENTS: Comma-separated list of allowed recipient patterns for mail_send and mail_forward.
  *   Supports wildcard (*) matching. If set, any recipient not matching causes an error.
  *   Example: "*@yourcompany.com,trusted@example.com"
  */


### PR DESCRIPTION
## Summary

Extends the `MACOS_MCP_ALLOWED_RECIPIENTS` and `MACOS_MCP_SEND_AS_DRAFT` security controls (introduced in #31 and #32) to the two remaining write paths that were missing them: `mail_forward` and `mail_reply`.

## Problem

`mail_forward` accepts arbitrary `to` addresses and defaults to `send=true`, meaning an attacker-crafted email body could instruct the LLM to forward sensitive emails to an external address — arguably the highest-risk gap since forwarding exfiltrates original email content. `mail_reply` also bypassed `MACOS_MCP_SEND_AS_DRAFT`, allowing immediate sends even when the user configured draft-only mode.

## Changes

### `forwardMessage()` (tools.ts)
- Validates the `to` parameter against `MACOS_MCP_ALLOWED_RECIPIENTS` before forwarding. Returns an error if any recipient is blocked.
- Honours `MACOS_MCP_SEND_AS_DRAFT` — forces `send = false` when the flag is set, creating a draft instead of sending.

### `replyTo()` (tools.ts)
- Honours `MACOS_MCP_SEND_AS_DRAFT` — forces `send = false` when the flag is set.
- No allowlist check needed since the recipient is determined by the original message (not user-supplied).

### Tool descriptions (register.ts)
- Updated `mail_reply` and `mail_forward` descriptions to document the new security controls.

### Config docstring (config.ts)
- Updated `MACOS_MCP_ALLOWED_RECIPIENTS` documentation to note it applies to `mail_forward` as well.

## Testing

- TypeScript compiles cleanly
- All 187 existing tests pass
- No new dependencies

Closes #35