### PR TITLE
feat(mail): allow move and set-flags in read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To disable all write operations (send, reply, forward, create, delete, etc.):
 }
 ```
 
-When enabled, write tools are not registered and won't appear in the tool list.
+When enabled, write tools are not registered and won't appear in the tool list, except `mail_move` and `mail_set_flags` (kept available for inbox triage workflows).
 Read operations (listing, searching, viewing) and FTS indexing remain available.
 
 ## Tools (33)

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -563,7 +563,7 @@ describe("isReadOnly", () => {
 
 // ─── Read-only integration: tool registration ────────────────────
 
-const MAIL_WRITE_TOOLS = ["mail_send", "mail_create_draft", "mail_reply", "mail_forward", "mail_move", "mail_set_flags"];
+const MAIL_WRITE_TOOLS = ["mail_send", "mail_create_draft", "mail_reply", "mail_forward"];
 const CALENDAR_WRITE_TOOLS = ["calendar_create_event", "calendar_modify_event", "calendar_delete_event"];
 const REMINDERS_WRITE_TOOLS = ["reminders_create", "reminders_complete", "reminders_delete"];
 
@@ -586,22 +586,26 @@ describe("read-only integration: registerMailTools", () => {
     }
   });
 
-  it("omits all 6 write tools when MACOS_MCP_READONLY=true", () => {
+  it("omits write-only mail tools but keeps mail_move and mail_set_flags when MACOS_MCP_READONLY=true", () => {
     process.env.MACOS_MCP_READONLY = "true";
     const { server, registeredTools } = makeMockServer();
     registerMailTools(server);
     for (const tool of MAIL_WRITE_TOOLS) {
       assert.ok(!registeredTools().includes(tool), `Expected ${tool} to be absent in read-only mode`);
     }
+    assert.ok(registeredTools().includes("mail_move"), "Expected mail_move to remain available in read-only mode");
+    assert.ok(registeredTools().includes("mail_set_flags"), "Expected mail_set_flags to remain available in read-only mode");
   });
 
-  it("includes all 6 write tools when MACOS_MCP_READONLY is not set", () => {
+  it("includes all write tools when MACOS_MCP_READONLY is not set", () => {
     delete process.env.MACOS_MCP_READONLY;
     const { server, registeredTools } = makeMockServer();
     registerMailTools(server);
     for (const tool of MAIL_WRITE_TOOLS) {
       assert.ok(registeredTools().includes(tool), `Expected ${tool} to be present in normal mode`);
     }
+    assert.ok(registeredTools().includes("mail_move"), "Expected mail_move to be present in normal mode");
+    assert.ok(registeredTools().includes("mail_set_flags"), "Expected mail_set_flags to be present in normal mode");
   });
 
   it("still registers read-only tools regardless of MACOS_MCP_READONLY", () => {

--- a/src/mail/register.ts
+++ b/src/mail/register.ts
@@ -236,6 +236,9 @@ export function registerMailTools(server: McpServer): void {
     } catch (e) { return err(e); }
   });
 
+  } // end read-only guard
+
+  // Keep mail move available in read-only mode to support inbox triage workflows.
   server.registerTool("mail_move", {
     title: "Move Email",
     description: "Move an email to a different mailbox. Source mailbox and account are auto-resolved from the message ID if not provided. Use when: organizing emails into folders, archiving messages",
@@ -254,6 +257,7 @@ export function registerMailTools(server: McpServer): void {
     } catch (e) { return err(e); }
   });
 
+  // Keep flag/read updates available even in read-only mode to support inbox triage.
   server.registerTool("mail_set_flags", {
     title: "Set Email Flags",
     description: "Set flagged and/or read status on an email. Mailbox and account are auto-resolved from the message ID if not provided. Use when: marking emails as read/unread, flagging important messages",
@@ -272,8 +276,6 @@ export function registerMailTools(server: McpServer): void {
       return ok(result, false);
     } catch (e) { return err(e); }
   });
-  } // end read-only guard
-
   // ─── FTS Tools ──────────────────────────────────────────────────
 
   server.registerTool("mail_search_body", {


### PR DESCRIPTION
## Summary
Implements issue #40 by allowing safe inbox triage actions in read-only mode.

## Problem
Read-only mode prevented users from finishing basic triage workflows after reviewing email:
- mark emails as read/unread
- move emails to another mailbox (for example, Deleted Items)

## What Changed
- Keeps mail_move registered when MACOS_MCP_READONLY=true
- Keeps mail_set_flags registered when MACOS_MCP_READONLY=true
- Keeps other write-only mail tools blocked in read-only mode
- Updates read-only integration tests
- Updates README read-only mode documentation

Closes #40