### PR TITLE
feat: add MACOS_MCP_CONFIRM_DESTRUCTIVE mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 | `MACOS_MCP_REMINDER_LISTS` | Comma-separated reminder list names to include | All lists |
 | `MACOS_MCP_WRITE_RATE_LIMIT` | Max write operations per minute | 10 |
 | `MACOS_MCP_READONLY` | Disable all write tools (`true` or `1`) | Not set (all tools) |
+| `MACOS_MCP_CONFIRM_DESTRUCTIVE` | Require `confirm: true` on destructive tools (`true` or `1`) | Not set |
 
 ### Read-Only Mode
 
@@ -90,6 +91,26 @@ To disable all write operations (send, reply, forward, create, delete, etc.):
 
 When enabled, write tools are not registered and won't appear in the tool list, except `mail_move` and `mail_set_flags` (kept available for inbox triage workflows).
 Read operations (listing, searching, viewing) and FTS indexing remain available.
+
+### Confirm Destructive Mode
+
+To require explicit confirmation before destructive actions (sending email, deleting events/reminders):
+
+```json
+{
+  "mcpServers": {
+    "macos": {
+      "command": "npx",
+      "args": ["macos-mcp-server"],
+      "env": {
+        "MACOS_MCP_CONFIRM_DESTRUCTIVE": "true"
+      }
+    }
+  }
+}
+```
+
+When enabled, destructive tools (`mail_send`, `mail_reply`, `mail_forward`, `calendar_delete_event`, `reminders_delete`) require a `confirm: true` parameter. If omitted, the tool returns a warning asking the LLM to check with the user first. For `mail_reply` and `mail_forward`, confirmation is only required when `send: true` (the default) — saving as draft does not require confirmation.
 
 ## Tools (33)
 

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -7,7 +7,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { sqlEscape, sqlLikeEscape, safeInt } from "../shared/sqlite.js";
 import { paginateArray, paginateRows, fromCoreDataTimestamp, sanitizeErrorMessage, stripInjectionPatterns, sanitizeBodyContent } from "../shared/types.js";
-import { isReadOnly, isSendAsDraft, isSanitizeBodies } from "../shared/config.js";
+import { isReadOnly, isSendAsDraft, isSanitizeBodies, isConfirmDestructive } from "../shared/config.js";
 import { jxaString, jxaStringArray } from "../shared/applescript.js";
 import { emlxSubpath, decodeQuotedPrintable, stripHtml } from "../mail/fts.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,6 +15,7 @@ import { registerMailTools } from "../mail/register.js";
 import { registerCalendarTools } from "../calendar/register.js";
 import { registerRemindersTools } from "../reminders/register.js";
 import { matchesAllowlist, findBlockedRecipient } from "../shared/config.js";
+import { needsConfirmation } from "../shared/mcp-helpers.js";
 
 // ─── sqlEscape ──────────────────────────────────────────────────
 
@@ -886,5 +887,78 @@ describe("isSanitizeBodies", () => {
   it("returns false for other values", () => {
     process.env.MACOS_MCP_SANITIZE_BODIES = "yes";
     assert.equal(isSanitizeBodies(), false);
+  });
+});
+
+// ─── isConfirmDestructive ────────────────────────────────────────
+
+describe("isConfirmDestructive", () => {
+  const originalEnv = process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+    } else {
+      process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = originalEnv;
+    }
+  });
+
+  it("returns false when env var is not set", () => {
+    delete process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+    assert.equal(isConfirmDestructive(), false);
+  });
+
+  it("returns true for 'true'", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
+    assert.equal(isConfirmDestructive(), true);
+  });
+
+  it("returns true for '1'", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "1";
+    assert.equal(isConfirmDestructive(), true);
+  });
+
+  it("returns false for other values", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "yes";
+    assert.equal(isConfirmDestructive(), false);
+  });
+});
+
+// ─── needsConfirmation ──────────────────────────────────────────
+
+describe("needsConfirmation", () => {
+  const originalEnv = process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+    } else {
+      process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = originalEnv;
+    }
+  });
+
+  it("returns null when confirm-destructive is not enabled", () => {
+    delete process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+    assert.equal(needsConfirmation(false, "test_tool", "Test action."), null);
+  });
+
+  it("returns null when confirm-destructive is enabled and confirm is true", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
+    assert.equal(needsConfirmation(true, "test_tool", "Test action."), null);
+  });
+
+  it("returns warning when confirm-destructive is enabled and confirm is false", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
+    const result = needsConfirmation(false, "mail_send", "This will send an email.");
+    assert.ok(result !== null);
+    assert.ok(result!.content[0].text.includes("mail_send"));
+    assert.ok(result!.content[0].text.includes("confirm: true"));
+  });
+
+  it("includes the description in the warning", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
+    const result = needsConfirmation(false, "test_tool", "This will delete everything.");
+    assert.ok(result !== null);
+    assert.ok(result!.content[0].text.includes("This will delete everything."));
   });
 });

--- a/src/calendar/register.ts
+++ b/src/calendar/register.ts
@@ -4,7 +4,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource } from "../shared/mcp-helpers.js";
+import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource, confirmParam, needsConfirmation } from "../shared/mcp-helpers.js";
 import { isReadOnly } from "../shared/config.js";
 import * as calendar from "./tools.js";
 
@@ -179,11 +179,14 @@ export function registerCalendarTools(server: McpServer): void {
     inputSchema: z.object({
       eventId: z.string().max(500),
       calendar: z.string().max(200, "Name too long"),
+      confirm: confirmParam,
     }).strict(),
     outputSchema: SuccessZ,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
-  }, async ({ eventId, calendar: cal }) => {
+  }, async ({ eventId, calendar: cal, confirm }) => {
     try {
+      const guard = needsConfirmation(confirm, "calendar_delete_event", "This will permanently delete the calendar event.");
+      if (guard) return guard;
       const result = await calendar.deleteEvent(eventId, cal);
       return ok(result, false);
     } catch (e) { return err(e); }

--- a/src/mail/register.ts
+++ b/src/mail/register.ts
@@ -4,7 +4,7 @@
 
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { ok, err, paginatedOutput, SuccessZ, SuccessMessageZ, resource } from "../shared/mcp-helpers.js";
+import { ok, err, paginatedOutput, SuccessZ, SuccessMessageZ, resource, confirmParam, needsConfirmation } from "../shared/mcp-helpers.js";
 import { sanitizeErrorMessage } from "../shared/types.js";
 import { isReadOnly } from "../shared/config.js";
 import * as mail from "./tools.js";
@@ -166,11 +166,14 @@ export function registerMailTools(server: McpServer): void {
       cc: z.array(z.string().email("Invalid email address")).optional().describe("CC addresses"),
       bcc: z.array(z.string().email("Invalid email address")).optional().describe("BCC addresses"),
       account: z.string().max(200, "Name too long").optional(),
+      confirm: confirmParam,
     }).strict(),
     outputSchema: SuccessMessageZ,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ to, subject, body, htmlBody, cc, bcc, account }) => {
+  }, async ({ to, subject, body, htmlBody, cc, bcc, account, confirm }) => {
     try {
+      const guard = needsConfirmation(confirm, "mail_send", `This will send an email to ${to.join(", ")}.`);
+      if (guard) return guard;
       const result = await mail.sendEmail(to, subject, body, cc, bcc, account, htmlBody);
       return ok(result, false);
     } catch (e) { return err(e); }
@@ -206,11 +209,16 @@ export function registerMailTools(server: McpServer): void {
       send: z.boolean().default(true).describe("Send immediately or save as draft"),
       mailbox: z.string().max(200, "Name too long").optional().describe("Mailbox name. If omitted, auto-resolved from the message ID."),
       account: z.string().max(200, "Name too long").optional().describe("Account name. If omitted, auto-resolved from the message ID."),
+      confirm: confirmParam,
     }).strict(),
     outputSchema: SuccessMessageZ,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ messageId, body, replyAll, send, mailbox, account }) => {
+  }, async ({ messageId, body, replyAll, send, mailbox, account, confirm }) => {
     try {
+      if (send) {
+        const guard = needsConfirmation(confirm, "mail_reply", "This will send a reply immediately.");
+        if (guard) return guard;
+      }
       const result = await mail.replyTo(messageId, body, replyAll, send, mailbox, account);
       return ok(result, false);
     } catch (e) { return err(e); }
@@ -226,11 +234,16 @@ export function registerMailTools(server: McpServer): void {
       send: z.boolean().default(true),
       mailbox: z.string().max(200, "Name too long").optional().describe("Mailbox name. If omitted, auto-resolved from the message ID."),
       account: z.string().max(200, "Name too long").optional().describe("Account name. If omitted, auto-resolved from the message ID."),
+      confirm: confirmParam,
     }).strict(),
     outputSchema: SuccessMessageZ,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-  }, async ({ messageId, to, body, send, mailbox, account }) => {
+  }, async ({ messageId, to, body, send, mailbox, account, confirm }) => {
     try {
+      if (send) {
+        const guard = needsConfirmation(confirm, "mail_forward", `This will forward the email to ${to.join(", ")}.`);
+        if (guard) return guard;
+      }
       const result = await mail.forwardMessage(messageId, to, body, send, mailbox, account);
       return ok(result, false);
     } catch (e) { return err(e); }

--- a/src/reminders/register.ts
+++ b/src/reminders/register.ts
@@ -4,7 +4,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource } from "../shared/mcp-helpers.js";
+import { ok, err, isoDateString, paginatedOutput, SuccessZ, SuccessIdZ, resource, confirmParam, needsConfirmation } from "../shared/mcp-helpers.js";
 import { isReadOnly } from "../shared/config.js";
 import * as reminders from "./tools.js";
 
@@ -126,11 +126,14 @@ export function registerRemindersTools(server: McpServer): void {
     inputSchema: z.object({
       reminderId: z.string().max(500),
       list: z.string().max(200, "Name too long"),
+      confirm: confirmParam,
     }).strict(),
     outputSchema: SuccessZ,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
-  }, async ({ reminderId, list }) => {
+  }, async ({ reminderId, list, confirm }) => {
     try {
+      const guard = needsConfirmation(confirm, "reminders_delete", "This will permanently delete the reminder.");
+      if (guard) return guard;
       const result = await reminders.deleteReminder(reminderId, list);
       return ok(result, false);
     } catch (e) { return err(e); }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -40,6 +40,17 @@ export function isReadOnly(): boolean {
 }
 
 /**
+ * When true, destructive tools (send email, delete event/reminder) require
+ * an explicit `confirm: true` parameter. If omitted, they return a warning
+ * asking the LLM to check with the user first.
+ * Controlled by MACOS_MCP_CONFIRM_DESTRUCTIVE=true|1.
+ */
+export function isConfirmDestructive(): boolean {
+  const val = process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE;
+  return val === "true" || val === "1";
+}
+
+/**
  * When true, mail_send saves to Mail.app drafts instead of sending.
  * Controlled by MACOS_MCP_SEND_AS_DRAFT=true|1.
  */

--- a/src/shared/mcp-helpers.ts
+++ b/src/shared/mcp-helpers.ts
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 import { sanitizeErrorMessage } from "./types.js";
+import { isConfirmDestructive } from "./config.js";
 
 /** Maximum characters for a JSON-stringified response before truncation kicks in. */
 const MAX_RESPONSE_CHARS = 25_000;
@@ -120,6 +121,33 @@ export function paginatedOutput<T extends z.ZodTypeAny>(itemSchema: T) {
     items: z.array(itemSchema),
     has_more: z.boolean(),
     next_offset: z.number().optional(),
+  };
+}
+
+/**
+ * Zod schema for the optional `confirm` parameter on destructive tools.
+ * Add this to inputSchema when `MACOS_MCP_CONFIRM_DESTRUCTIVE` is enabled.
+ */
+export const confirmParam = z.boolean().default(false).describe(
+  "Set to true to confirm this destructive action. When MACOS_MCP_CONFIRM_DESTRUCTIVE is enabled, the tool will return a warning if this is not true."
+);
+
+/**
+ * Check if a destructive tool should proceed.
+ * Returns a warning response if confirmation is required but not provided,
+ * or null if the tool should proceed normally.
+ */
+export function needsConfirmation(
+  confirm: boolean,
+  toolName: string,
+  description: string
+): ReturnType<typeof ok> | null {
+  if (!isConfirmDestructive() || confirm) return null;
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Action "${toolName}" requires confirmation. ${description} Please check with the user, then call again with confirm: true.`,
+    }],
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `MACOS_MCP_CONFIRM_DESTRUCTIVE` env var that requires destructive tools to be called with `confirm: true` before executing
- When enabled and `confirm` is not true, tools return a warning asking the LLM to check with the user first
- For `mail_reply` and `mail_forward`, confirmation is only required when `send: true` (saving as draft skips confirmation)

Applies to: `mail_send`, `mail_reply`, `mail_forward`, `calendar_delete_event`, `reminders_delete`

Inspired by the `--confirm-destructive` pattern in [griches/apple-mcp](https://github.com/griches/apple-mcp).

## Implementation

- `isConfirmDestructive()` config function in `shared/config.ts`
- Reusable `confirmParam` Zod schema and `needsConfirmation()` helper in `shared/mcp-helpers.ts`
- 8 new tests covering config parsing and confirmation logic
- README updated with documentation and config example

## Test plan

- [x] 195 tests pass (including 8 new)
- [x] Build clean
- [ ] Manual: set `MACOS_MCP_CONFIRM_DESTRUCTIVE=true`, verify `mail_send` returns warning without `confirm: true`
- [ ] Manual: verify tools execute normally when env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)