### PR TITLE
Fix: Include structuredContent in markdown-formatted responses

### DIFF
--- a/src/shared/mcp-helpers.ts
+++ b/src/shared/mcp-helpers.ts
@@ -55,15 +55,19 @@ export function toMarkdown(data: unknown, indent = 0): string {
 
 /** Format a successful tool response with structured content. */
 export function ok(data: object, pretty = true, format?: "json" | "markdown") {
-  // Markdown format: return plain text without structuredContent
+  // Ensure data is properly typed as a record
+  const dataRecord = data as Record<string, unknown>;
+
+  // Markdown format: return plain text with structuredContent for schema validation
   if (format === "markdown") {
     return {
       content: [{ type: "text" as const, text: toMarkdown(data) }],
+      structuredContent: dataRecord,
     };
   }
 
   // JSON format (default): check for truncation
-  const result = data as Record<string, unknown>;
+  const result = dataRecord;
   let json = JSON.stringify(result, null, pretty ? 2 : undefined);
 
   if (json.length > MAX_RESPONSE_CHARS && Array.isArray(result.items)) {
@@ -72,7 +76,7 @@ export function ok(data: object, pretty = true, format?: "json" | "markdown") {
 
     // Binary search for the right number of items that fits
     while (items.length > 0) {
-      const candidate = {
+      const candidate: Record<string, unknown> = {
         ...result,
         items,
         truncation_message: `Response truncated. Use pagination (offset/limit) or filters to narrow results. Showing ${items.length} of ${totalItems} items.`,
@@ -89,7 +93,7 @@ export function ok(data: object, pretty = true, format?: "json" | "markdown") {
     }
 
     // Fallback: no items fit
-    const fallback = {
+    const fallback: Record<string, unknown> = {
       ...result,
       items: [],
       truncation_message: `Response truncated. Use pagination (offset/limit) or filters to narrow results. Showing 0 of ${totalItems} items.`,
@@ -143,12 +147,9 @@ export function needsConfirmation(
   description: string
 ): ReturnType<typeof ok> | null {
   if (!isConfirmDestructive() || confirm) return null;
-  return {
-    content: [{
-      type: "text" as const,
-      text: `Action "${toolName}" requires confirmation. ${description} Please check with the user, then call again with confirm: true.`,
-    }],
-  };
+  return ok({
+    warning: `Action "${toolName}" requires confirmation. ${description} Please check with the user, then call again with confirm: true.`,
+  });
 }
 
 /** Common output schemas for simple responses. */


### PR DESCRIPTION
### Problem
When calling tools with `response_format="markdown"` (like `daily_briefing`), an MCP validation error was thrown:
```
MCP error -32602: Output validation error: Tool mail_get_emails has an output schema but no structured content was provided
```

### Root Cause
The `ok()` function in `src/shared/mcp-helpers.ts` was returning responses without `structuredContent` when `format === "markdown"`. However, MCP validation requires `structuredContent` to be present whenever a tool declares an `outputSchema`, regardless of the response format requested.

### Solution
- Updated the `ok()` function to include `structuredContent` in both JSON and markdown responses
- Properly typed `structuredContent` as `Record<string, unknown>` to satisfy TypeScript requirements
- Updated `needsConfirmation()` to use the `ok()` helper for consistent return types

### Testing
✅ All shared/core unit tests pass (137 tests)  
✅ Build succeeds with no TypeScript errors  
✅ Manual test confirms `daily_briefing` with `response_format="markdown"` returns both content and structuredContent  

### Changes
- `src/shared/mcp-helpers.ts`: Fixed `ok()` and `needsConfirmation()` functions

Fixes #48