### PR TITLE
fix: calendar_get_events returns empty for same-day queries (#50)

### DIFF
--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { toCoreDataTimestamp, statusLabel, participantStatusLabel, rowToEventSummary } from "../calendar/tools.js";
+import { toCoreDataTimestamp, statusLabel, participantStatusLabel, rowToEventSummary, normalizeDateRangeMs } from "../calendar/tools.js";
 import { CORE_DATA_EPOCH_OFFSET } from "../shared/types.js";
 
 // ─── toCoreDataTimestamp ─────────────────────────────────────────
@@ -184,5 +184,58 @@ describe("rowToEventSummary", () => {
     assert.equal(result.calendar, "");
     assert.equal(result.startDate, "");
     assert.equal(result.endDate, "");
+  });
+});
+
+// ─── normalizeDateRangeMs (#50) ──────────────────────────────────
+
+const MS_PER_DAY = 86_400_000;
+
+describe("normalizeDateRangeMs", () => {
+  it("returns same values when end is after start", () => {
+    const [s, e] = normalizeDateRangeMs("2026-04-17", "2026-04-18");
+    assert.equal(s, new Date("2026-04-17").getTime());
+    assert.equal(e, new Date("2026-04-18").getTime());
+  });
+
+  it("extends end by one day when startDate equals endDate", () => {
+    const [s, e] = normalizeDateRangeMs("2026-04-17", "2026-04-17");
+    assert.equal(s, new Date("2026-04-17").getTime());
+    assert.equal(e, new Date("2026-04-17").getTime() + MS_PER_DAY);
+  });
+
+  it("extends end by one day when startDate equals endDate with datetimes", () => {
+    const [s, e] = normalizeDateRangeMs("2026-04-17T00:00:00Z", "2026-04-17T00:00:00Z");
+    assert.equal(s, new Date("2026-04-17T00:00:00Z").getTime());
+    assert.equal(e, s + MS_PER_DAY);
+  });
+
+  it("corrects inverted range (end before start)", () => {
+    const [s, e] = normalizeDateRangeMs("2026-04-18", "2026-04-17");
+    assert.equal(s, new Date("2026-04-18").getTime());
+    assert.equal(e, s + MS_PER_DAY);
+  });
+
+  it("event at noon is included in same-day range", () => {
+    const [sMs, eMs] = normalizeDateRangeMs("2026-04-17", "2026-04-17");
+    const eventStart = new Date("2026-04-17T12:00:00Z").getTime();
+    assert.ok(eventStart >= sMs && eventStart < eMs, "noon event should be in range");
+  });
+
+  it("event at 23:59 is included in same-day range", () => {
+    const [sMs, eMs] = normalizeDateRangeMs("2026-04-17", "2026-04-17");
+    const eventStart = new Date("2026-04-17T23:59:59Z").getTime();
+    assert.ok(eventStart >= sMs && eventStart < eMs, "late event should be in range");
+  });
+
+  it("event on next day is excluded from same-day range", () => {
+    const [sMs, eMs] = normalizeDateRangeMs("2026-04-17", "2026-04-17");
+    const eventStart = new Date("2026-04-18T00:00:00Z").getTime();
+    assert.ok(!(eventStart >= sMs && eventStart < eMs), "next day event should not be in range");
+  });
+
+  it("multi-day range is unchanged", () => {
+    const [s, e] = normalizeDateRangeMs("2026-04-17", "2026-04-20");
+    assert.equal(e - s, 3 * MS_PER_DAY);
   });
 });

--- a/src/calendar/tools.ts
+++ b/src/calendar/tools.ts
@@ -84,6 +84,18 @@ export type { PaginatedResult } from "../shared/types.js";
 
 // ─── Helpers ────────────────────────────────────────────────────
 
+/**
+ * Normalize a date range so that same-day queries work correctly.
+ * When endMs <= startMs (same date or inverted), extend end by one day.
+ * Returns [startMs, endMs] in milliseconds.
+ */
+export function normalizeDateRangeMs(startDate: string, endDate: string): [number, number] {
+  const sMs = new Date(startDate).getTime();
+  let eMs = new Date(endDate).getTime();
+  if (eMs <= sMs) eMs = sMs + MS_PER_DAY;
+  return [sMs, eMs];
+}
+
 /** Build a SQL WHERE clause to filter by configured calendar names. */
 function calendarWhereClause(calendar?: string): string {
   if (calendar) {
@@ -170,7 +182,9 @@ export async function getEvents(
   offset = 0
 ): Promise<PaginatedResult<EventSummary>> {
   const startTs = toCoreDataTimestamp(startDate);
-  const endTs = toCoreDataTimestamp(endDate);
+  let endTs = toCoreDataTimestamp(endDate);
+  // When startDate === endDate (same-day query), extend end by one day (#50)
+  if (endTs <= startTs) endTs = startTs + SECONDS_PER_DAY;
   const calFilter = calendarWhereClause(calendar);
 
   const rows = await sqliteQuery(
@@ -184,12 +198,11 @@ export async function getEvents(
   );
 
   // Post-filter for precise range (day column is date-granularity)
+  const [sMs, eMs] = normalizeDateRangeMs(startDate, endDate);
   const allItems = rows
     .map(rowToEventSummary)
     .filter((e) => {
       const start = new Date(e.startDate).getTime();
-      const sMs = new Date(startDate).getTime();
-      const eMs = new Date(endDate).getTime();
       return start >= sMs && start < eMs;
     });
 


### PR DESCRIPTION
When startDate equals endDate (e.g. both '2026-04-17'), the post-filter condition 'start >= sMs && start < eMs' is impossible to satisfy since sMs === eMs. The SQL WHERE clause had the same zero-width range issue.

Extract normalizeDateRangeMs() helper that extends the end by one day when the range is zero-width. Applied to both the SQL query and the post-filter. Includes 8 unit tests.

Closes #50