### PR TITLE
feat(reminders): multi-database SQLite for non-iCloud accounts

### DIFF
--- a/src/__tests__/reminders.test.ts
+++ b/src/__tests__/reminders.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for Reminders tool-level pure functions and multi-database logic.
+ * These tests run without macOS databases — they only test parsing/formatting logic.
+ * Integration tests (live DB/JXA) are at the bottom and require macOS + Reminders.app.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { getReminderLists } from "../shared/config.js";
+import { ReminderSummaryZ } from "../reminders/register.js";
+
+// ─── getReminderLists (config) ───────────────────────────────────
+
+describe("getReminderLists", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.MACOS_MCP_REMINDER_LISTS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MACOS_MCP_REMINDER_LISTS;
+    } else {
+      process.env.MACOS_MCP_REMINDER_LISTS = originalEnv;
+    }
+  });
+
+  it("returns null when env var is not set", () => {
+    delete process.env.MACOS_MCP_REMINDER_LISTS;
+    assert.equal(getReminderLists(), null);
+  });
+
+  it("returns array of trimmed list names", () => {
+    process.env.MACOS_MCP_REMINDER_LISTS = " Work , Personal , Groceries ";
+    const result = getReminderLists();
+    assert.deepEqual(result, ["Work", "Personal", "Groceries"]);
+  });
+
+  it("filters out empty entries", () => {
+    process.env.MACOS_MCP_REMINDER_LISTS = "Work,,Personal,";
+    const result = getReminderLists();
+    assert.deepEqual(result, ["Work", "Personal"]);
+  });
+
+  it("returns null for empty string", () => {
+    process.env.MACOS_MCP_REMINDER_LISTS = "";
+    assert.equal(getReminderLists(), null);
+  });
+
+  it("handles single list", () => {
+    process.env.MACOS_MCP_REMINDER_LISTS = "Tasks";
+    assert.deepEqual(getReminderLists(), ["Tasks"]);
+  });
+});
+
+// ─── ReminderSummaryZ schema validation ──────────────────────────
+
+describe("ReminderSummaryZ schema", () => {
+  it("parses a valid reminder summary", () => {
+    const valid = {
+      id: "x-apple-reminder://ABC-123",
+      name: "Buy groceries",
+      completed: false,
+      completionDate: "",
+      dueDate: "2026-04-15T09:00:00.000Z",
+      priority: 1,
+      list: "Reminders",
+      flagged: false,
+    };
+    const result = ReminderSummaryZ.parse(valid);
+    assert.deepEqual(result, valid);
+  });
+
+  it("rejects missing required fields", () => {
+    assert.throws(() => ReminderSummaryZ.parse({ id: "ABC" }));
+  });
+
+  it("rejects wrong types", () => {
+    assert.throws(() =>
+      ReminderSummaryZ.parse({
+        id: "ABC",
+        name: 123, // should be string
+        completed: "yes", // should be boolean
+        completionDate: "",
+        dueDate: "",
+        priority: 0,
+        list: "x",
+        flagged: false,
+      })
+    );
+  });
+});
+
+// ─── Reminders tool registration ─────────────────────────────────
+
+describe("Reminders tool registration", () => {
+  it("can import registerRemindersTools without error", async () => {
+    const mod = await import("../reminders/register.js");
+    assert.equal(typeof mod.registerRemindersTools, "function");
+    assert.equal(typeof mod.registerRemindersResources, "function");
+  });
+
+  it("exports ReminderSummaryZ schema", async () => {
+    const mod = await import("../reminders/register.js");
+    assert.ok(mod.ReminderSummaryZ);
+    assert.equal(typeof mod.ReminderSummaryZ.parse, "function");
+  });
+});
+
+// ─── findAllRemindersDbs ─────────────────────────────────────────
+
+import { findAllRemindersDbs } from "../reminders/tools.js";
+
+describe("findAllRemindersDbs", () => {
+  it("returns an array of database paths", () => {
+    const dbs = findAllRemindersDbs();
+    assert.ok(Array.isArray(dbs), "Should return an array");
+    assert.ok(dbs.length > 0, "Should find at least one database");
+    for (const db of dbs) {
+      assert.ok(db.endsWith(".sqlite"), "Each path should end with .sqlite");
+      assert.ok(existsSync(db), `Database file should exist: ${db}`);
+    }
+  });
+
+  it("returns consistent results on repeated calls", () => {
+    const dbs1 = findAllRemindersDbs();
+    const dbs2 = findAllRemindersDbs();
+    assert.deepEqual(dbs1, dbs2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// INTEGRATION TESTS — require macOS + Reminders.app database
+// Skipped in CI (JXA needs a running Reminders.app with GUI session)
+// ═══════════════════════════════════════════════════════════════════
+
+import * as reminders from "../reminders/tools.js";
+
+const isCI = !!process.env.CI;
+
+describe("Reminders integration: listReminderLists", { skip: isCI }, () => {
+  it("returns at least one list", async () => {
+    const lists = await reminders.listReminderLists();
+    assert.ok(Array.isArray(lists));
+    assert.ok(lists.length > 0, "Should have at least one reminder list");
+    for (const l of lists) {
+      assert.ok(l.name, "List should have a name");
+      assert.ok(l.id, "List should have an id");
+      assert.equal(typeof l.count, "number");
+    }
+  });
+
+  it("does not include system lists", async () => {
+    const lists = await reminders.listReminderLists();
+    for (const l of lists) {
+      assert.notEqual(l.name, "SiriFoundInApps", "Should not include system lists");
+    }
+  });
+
+  it("includes Exchange/non-iCloud lists visible via JXA", async () => {
+    // Verify that all lists visible in JXA are also visible via our multi-DB approach
+    const { executeJxa } = await import("../shared/applescript.js");
+    const jxaLists = await executeJxa<Array<{ name: string }>>(`
+      const Rem = Application("Reminders");
+      const lists = Rem.lists();
+      JSON.stringify(lists.map(l => ({ name: l.name() })));
+    `);
+    const sqliteLists = await reminders.listReminderLists();
+    const sqliteNames = new Set(sqliteLists.map((l) => l.name));
+
+    for (const jl of jxaLists) {
+      assert.ok(
+        sqliteNames.has(jl.name),
+        `JXA list "${jl.name}" should also appear in multi-DB SQLite results`
+      );
+    }
+  });
+});
+
+describe("Reminders integration: getReminders", { skip: isCI }, () => {
+  it("returns paginated incomplete reminders", async () => {
+    const result = await reminders.getReminders(undefined, "incomplete", 5, 0);
+    assert.ok(result.total >= 0);
+    assert.ok(result.items.length <= 5);
+    assert.equal(result.offset, 0);
+    assert.equal(typeof result.has_more, "boolean");
+    for (const r of result.items) {
+      assert.equal(r.completed, false, "Incomplete filter should only return uncompleted");
+    }
+  });
+
+  it("returns reminders from all accounts when no list filter", async () => {
+    const result = await reminders.getReminders(undefined, "all", 200, 0);
+    const listNames = new Set(result.items.map((r) => r.list));
+    // If user has multiple accounts, we should see lists from different DBs
+    assert.ok(listNames.size >= 1, "Should have reminders from at least one list");
+  });
+
+  it("filters by specific list name", async () => {
+    const lists = await reminders.listReminderLists();
+    if (lists.length > 0) {
+      const targetList = lists[0].name;
+      const result = await reminders.getReminders(targetList, "all", 50, 0);
+      for (const r of result.items) {
+        assert.equal(r.list, targetList, `All results should be from "${targetList}"`);
+      }
+    }
+  });
+
+  it("returns correct pagination metadata", async () => {
+    const page1 = await reminders.getReminders(undefined, "all", 2, 0);
+    if (page1.total > 2) {
+      assert.equal(page1.has_more, true);
+      assert.equal(page1.next_offset, 2);
+      const page2 = await reminders.getReminders(undefined, "all", 2, 2);
+      assert.equal(page2.offset, 2);
+    }
+  });
+
+  it("reminder summaries have all required fields", async () => {
+    const result = await reminders.getReminders(undefined, "all", 3, 0);
+    for (const r of result.items) {
+      assert.ok(r.id, "Should have id");
+      assert.ok(r.id.startsWith(reminders.REMINDER_ID_PREFIX), "ID should have prefix");
+      assert.equal(typeof r.name, "string");
+      assert.equal(typeof r.completed, "boolean");
+      assert.equal(typeof r.completionDate, "string");
+      assert.equal(typeof r.dueDate, "string");
+      assert.equal(typeof r.priority, "number");
+      assert.ok(r.list, "Should have list name");
+      assert.equal(typeof r.flagged, "boolean");
+    }
+  });
+});
+
+describe("Reminders integration: getReminder", { skip: isCI }, () => {
+  it("returns full reminder details", async () => {
+    const all = await reminders.getReminders(undefined, "all", 1, 0);
+    if (all.items.length > 0) {
+      const r = all.items[0];
+      const detail = await reminders.getReminder(r.id, r.list);
+      assert.ok(detail.id);
+      assert.ok(detail.name);
+      assert.equal(typeof detail.body, "string");
+      assert.ok(detail.creationDate, "Should have creation date");
+      assert.ok(detail.modificationDate, "Should have modification date");
+      assert.equal(detail.list, r.list);
+    }
+  });
+
+  it("throws for non-existent reminder", async () => {
+    await assert.rejects(
+      () => reminders.getReminder("00000000-0000-0000-0000-000000000000", "Reminders"),
+      /not found/i
+    );
+  });
+});
+
+describe("Reminders integration: CRUD lifecycle", { skip: isCI }, () => {
+  const testName = `MCP Unit Test Reminder ${Date.now()}`;
+  let createdList: string | null = null;
+
+  it("creates a reminder, reads it, and deletes it", async () => {
+    // 1. Create in default list
+    const created = await reminders.createReminder(testName, "Reminders", undefined, "Test body");
+    assert.ok(created.success);
+    assert.ok(created.id);
+    createdList = "Reminders";
+
+    // 2. Delete via JXA targeting only the specific list (faster than scanning all)
+    const { executeJxaWrite, jxaString } = await import("../shared/applescript.js");
+    const deleted = await executeJxaWrite<{success: boolean}>(`
+      const Rem = Application("Reminders");
+      const l = Rem.lists.byName(${jxaString(createdList)});
+      const matches = l.reminders.whose({name: ${jxaString(testName)}})();
+      for (const r of matches) Rem.delete(r);
+      JSON.stringify({success: true});
+    `);
+    assert.ok(deleted.success);
+    createdList = null;
+  });
+
+  afterEach(async () => {
+    // Safety cleanup if test failed partway through
+    if (!createdList) return;
+    try {
+      const { executeJxaWrite, jxaString } = await import("../shared/applescript.js");
+      await executeJxaWrite(`
+        const Rem = Application("Reminders");
+        const l = Rem.lists.byName(${jxaString(createdList)});
+        const matches = l.reminders.whose({name: {_contains: "MCP Unit Test Reminder"}})();
+        for (const r of matches) Rem.delete(r);
+        JSON.stringify({success: true});
+      `);
+    } catch { /* best-effort cleanup */ }
+  });
+});

--- a/src/reminders/tools.ts
+++ b/src/reminders/tools.ts
@@ -1,8 +1,13 @@
 /**
  * Apple Reminders MCP tools.
  *
- * Read operations query the Reminders SQLite database directly for instant
- * results. Write operations use JXA since the database is read-only.
+ * Hybrid read strategy:
+ *   - macOS stores each Reminders account in a separate SQLite file under
+ *     ~/Library/Group Containers/group.com.apple.reminders/Container_v1/Stores/
+ *   - The previous single-DB approach only queried the largest file, missing
+ *     non-iCloud accounts (Exchange, etc.) stored in smaller databases.
+ *   - Now we query ALL viable .sqlite files and merge results.
+ *   - Write operations always use JXA (database is read-only).
  *
  * Provides: list_reminder_lists, get_reminders, get_reminder,
  * create_reminder, complete_reminder, delete_reminder
@@ -12,17 +17,24 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { readdirSync, statSync } from "node:fs";
 import { executeJxa, executeJxaWrite, jxaString } from "../shared/applescript.js";
-import { sqliteQuery, sqlEscape, safeInt } from "../shared/sqlite.js";
+import { sqliteQuery, SqliteRow, sqlEscape, safeInt } from "../shared/sqlite.js";
 import { getReminderLists } from "../shared/config.js";
 import { PaginatedResult, paginateRows, CORE_DATA_EPOCH_OFFSET, SECONDS_PER_DAY, fromCoreDataTimestamp } from "../shared/types.js";
 
 export const REMINDER_ID_PREFIX = "x-apple-reminder://";
 
+/** Minimum file size (bytes) to consider a .sqlite file as containing real data. */
+const MIN_DB_SIZE = 200 * 1024; // 200 KB — empty/placeholder databases are ~32-50 KB
+
+/** Internal system list names that should never appear in user-facing results. */
+const SYSTEM_LIST_NAMES = new Set(["SiriFoundInApps"]);
+
 /**
- * Find the active Reminders SQLite database.
- * macOS stores multiple .sqlite files but typically only one has data.
+ * Find ALL active Reminders SQLite databases (one per account).
+ * macOS stores each account (iCloud, Exchange, etc.) in a separate .sqlite file.
+ * We filter out tiny placeholder files and return paths for all viable databases.
  */
-function findRemindersDb(): string {
+export function findAllRemindersDbs(): string[] {
   const storesDir = join(
     homedir(),
     "Library/Group Containers/group.com.apple.reminders/Container_v1/Stores"
@@ -36,36 +48,46 @@ function findRemindersDb(): string {
   if (files.length === 0) {
     throw new Error(`No .sqlite files found in: ${storesDir}`);
   }
-  // macOS stores multiple .sqlite files in this directory, but typically
-  // only one has actual reminder data. We pick the largest file because
-  // empty/placeholder databases are small (~32KB), while the active
-  // database with real data is significantly larger.
-  // Note: This heuristic could theoretically pick the wrong file if a user
-  // has multiple accounts with similar-sized databases.
-  let best = files[0];
-  let bestSize = 0;
+
+  const viable: string[] = [];
   for (const f of files) {
     try {
-      const { size } = statSync(join(storesDir, f));
-      if (size > bestSize) {
-        bestSize = size;
-        best = f;
+      const fullPath = join(storesDir, f);
+      const { size } = statSync(fullPath);
+      if (size >= MIN_DB_SIZE) {
+        viable.push(fullPath);
       }
     } catch { /* skip inaccessible files */ }
   }
-  return join(storesDir, best);
+
+  if (viable.length === 0) {
+    throw new Error(`No Reminders databases with data found in: ${storesDir}`);
+  }
+  return viable;
 }
 
-let _remindersDb: string | null = null;
-let _remindersDbExpiry = 0;
+let _remindersDbs: string[] | null = null;
+let _remindersDbsExpiry = 0;
 const DB_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
-function getRemindersDb(): string {
-  if (!_remindersDb || Date.now() > _remindersDbExpiry) {
-    _remindersDb = findRemindersDb();
-    _remindersDbExpiry = Date.now() + DB_CACHE_TTL_MS;
+function getAllRemindersDbs(): string[] {
+  if (!_remindersDbs || Date.now() > _remindersDbsExpiry) {
+    _remindersDbs = findAllRemindersDbs();
+    _remindersDbsExpiry = Date.now() + DB_CACHE_TTL_MS;
   }
-  return _remindersDb;
+  return _remindersDbs;
+}
+
+/**
+ * Run a SQL query across all Reminders databases and merge results.
+ * Gracefully skips databases that error (e.g. locked or incompatible schema).
+ */
+async function queryAllDbs<T extends SqliteRow = SqliteRow>(sql: string): Promise<T[]> {
+  const dbs = getAllRemindersDbs();
+  const results = await Promise.all(
+    dbs.map((db) => sqliteQuery<T>(db, sql).catch(() => []))
+  );
+  return results.flat();
 }
 
 /** Build SQL WHERE clause for configured reminder lists. */
@@ -109,13 +131,11 @@ export interface ReminderFull extends ReminderSummary {
 // PaginatedResult<T> imported from shared/types.ts
 export type { PaginatedResult } from "../shared/types.js";
 
-// ─── Read Tools (SQLite — instant) ──────────────────────────────
+// ─── Read Tools (SQLite — multi-database, instant) ──────────────
 
 export async function listReminderLists(): Promise<ReminderList[]> {
-  const db = getRemindersDb();
   const listFilter = listWhereClause();
-  const rows = await sqliteQuery(
-    db,
+  const rows = await queryAllDbs(
     `SELECT l.ZNAME, l.ZCKIDENTIFIER,
        (SELECT COUNT(*) FROM ZREMCDREMINDER r
         WHERE r.ZLIST = l.Z_PK AND r.ZMARKEDFORDELETION = 0 AND r.ZCOMPLETED = 0) as cnt
@@ -125,11 +145,23 @@ export async function listReminderLists(): Promise<ReminderList[]> {
      ORDER BY l.ZNAME;`
   );
 
-  return rows.map((r) => ({
-    name: String(r.ZNAME || ""),
-    id: String(r.ZNAME || ""),
-    count: typeof r.cnt === "number" ? r.cnt : parseInt(String(r.cnt || "0"), 10),
-  }));
+  // Deduplicate by name (same list could appear as marked-for-deletion in one DB
+  // and active in another) and filter out system lists
+  const seen = new Map<string, ReminderList>();
+  for (const r of rows) {
+    const name = String(r.ZNAME || "");
+    if (SYSTEM_LIST_NAMES.has(name)) continue;
+    const count = typeof r.cnt === "number" ? r.cnt : parseInt(String(r.cnt || "0"), 10);
+    const existing = seen.get(name);
+    if (existing) {
+      // Merge counts from the same-named list across databases
+      existing.count += count;
+    } else {
+      seen.set(name, { name, id: name, count });
+    }
+  }
+
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function getReminders(
@@ -138,7 +170,6 @@ export async function getReminders(
   limit = 50,
   offset = 0
 ): Promise<PaginatedResult<ReminderSummary>> {
-  const db = getRemindersDb();
   const listFilter = listWhereClause(list);
 
   // Use local timezone for date boundaries
@@ -174,31 +205,44 @@ export async function getReminders(
 
   const baseWhere = `r.ZMARKEDFORDELETION = 0 ${filterSql} ${listFilter}`;
 
-  const [rows, countRows] = await Promise.all([
-    sqliteQuery(
-      db,
-      `SELECT r.ZCKIDENTIFIER, r.ZTITLE, r.ZCOMPLETED, r.ZCOMPLETIONDATE,
-         r.ZDUEDATE, r.ZPRIORITY, r.ZFLAGGED, l.ZNAME as list_name
-       FROM ZREMCDREMINDER r
-       JOIN ZREMCDBASELIST l ON r.ZLIST = l.Z_PK
-       WHERE ${baseWhere}
-       ORDER BY
-         CASE WHEN r.ZDUEDATE IS NOT NULL THEN 0 ELSE 1 END,
-         r.ZDUEDATE
-       LIMIT ${safeInt(limit)} OFFSET ${safeInt(offset)};`
+  // Query all databases in parallel
+  const dbs = getAllRemindersDbs();
+  const [allRows, allCounts] = await Promise.all([
+    Promise.all(
+      dbs.map((db) =>
+        sqliteQuery(
+          db,
+          `SELECT r.ZCKIDENTIFIER, r.ZTITLE, r.ZCOMPLETED, r.ZCOMPLETIONDATE,
+             r.ZDUEDATE, r.ZPRIORITY, r.ZFLAGGED, l.ZNAME as list_name
+           FROM ZREMCDREMINDER r
+           JOIN ZREMCDBASELIST l ON r.ZLIST = l.Z_PK
+           WHERE ${baseWhere}
+           ORDER BY
+             CASE WHEN r.ZDUEDATE IS NOT NULL THEN 0 ELSE 1 END,
+             r.ZDUEDATE;`
+        ).catch(() => [])
+      )
     ),
-    sqliteQuery(
-      db,
-      `SELECT COUNT(*) as total
-       FROM ZREMCDREMINDER r
-       JOIN ZREMCDBASELIST l ON r.ZLIST = l.Z_PK
-       WHERE ${baseWhere};`
+    Promise.all(
+      dbs.map((db) =>
+        sqliteQuery(
+          db,
+          `SELECT COUNT(*) as total
+           FROM ZREMCDREMINDER r
+           JOIN ZREMCDBASELIST l ON r.ZLIST = l.Z_PK
+           WHERE ${baseWhere};`
+        ).catch(() => [{ total: 0 }])
+      )
     ),
   ]);
 
-  const total = safeInt(countRows[0]?.total ?? 0);
+  const rows = allRows.flat().filter((r) => !SYSTEM_LIST_NAMES.has(String(r.list_name || "")));
+  const total = allCounts.flat().reduce(
+    (sum, r) => sum + safeInt(r?.total ?? 0),
+    0
+  );
 
-  const items = rows.map((r) => ({
+  const items: ReminderSummary[] = rows.map((r) => ({
     id: REMINDER_ID_PREFIX + String(r.ZCKIDENTIFIER || ""),
     name: String(r.ZTITLE || ""),
     completed: r.ZCOMPLETED === 1 || r.ZCOMPLETED === "1",
@@ -209,19 +253,29 @@ export async function getReminders(
     flagged: r.ZFLAGGED === 1 || r.ZFLAGGED === "1",
   }));
 
-  return paginateRows(items, total, offset);
+  // Re-sort merged results from multiple databases
+  items.sort((a, b) => {
+    const aHasDue = a.dueDate !== "";
+    const bHasDue = b.dueDate !== "";
+    if (aHasDue !== bHasDue) return aHasDue ? -1 : 1;
+    if (aHasDue && bHasDue) return a.dueDate.localeCompare(b.dueDate);
+    return 0;
+  });
+
+  // Apply pagination to merged results
+  const paged = items.slice(offset, offset + limit);
+  return paginateRows(paged, total, offset);
 }
 
 export async function getReminder(
   reminderId: string,
   list: string
 ): Promise<ReminderFull> {
-  const db = getRemindersDb();
   // Strip x-apple-reminder:// prefix if present for DB lookup
   const ckId = reminderId.replace(REMINDER_ID_PREFIX, "");
 
-  const rows = await sqliteQuery(
-    db,
+  // Search across all databases — the reminder could be in any account's DB
+  const rows = await queryAllDbs(
     `SELECT r.ZCKIDENTIFIER, r.ZTITLE, r.ZCOMPLETED, r.ZCOMPLETIONDATE,
        r.ZDUEDATE, r.ZPRIORITY, r.ZFLAGGED, r.ZNOTES,
        r.ZCREATIONDATE, r.ZLASTMODIFIEDDATE, l.ZNAME as list_name


### PR DESCRIPTION
### Summary

macOS stores each Reminders account (iCloud, Exchange, etc.) in a separate `.sqlite` file under the `Stores/` directory. The previous implementation only queried the largest file, missing non-iCloud accounts entirely (e.g. Exchange "Tasks" list).

Split out from #43 per reviewer request — the Notes PR should land first, then this can be reviewed independently.

### Changes

- Replace single-DB `findRemindersDb()` with `findAllRemindersDbs()` that discovers all viable `.sqlite` files (filtered by min size)
- Add `queryAllDbs()` helper to run SQL across all databases and merge results
- Update `listReminderLists()`, `getReminders()`, `getReminder()` to query all databases in parallel and merge/deduplicate
- Filter out system lists (`SiriFoundInApps`)
- Add comprehensive test suite (`reminders.test.ts`) with CI skip pattern matching the notes module convention

### Files Changed

- `src/reminders/tools.ts` — multi-DB query logic
- `src/__tests__/reminders.test.ts` — new test suite (integration tests skipped in CI)

Related to #42