### PR TITLE
chore: rename project from macos-mcp to mac-apps-mcp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in macos-mcp-server
+about: Report a bug in mac-apps-mcp-server
 labels: bug
 ---
 
@@ -21,5 +21,5 @@ What actually happened. Include any error messages or log output.
 ## Environment
 - macOS version:
 - Node.js version:
-- macos-mcp-server version:
+- mac-apps-mcp-server version:
 - MCP client (e.g., Claude Desktop):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# macos-mcp
+# mac-apps-mcp
 
 MCP server for macOS that gives Claude access to Apple Mail, Calendar, Reminders, and Contacts. All reads hit SQLite databases directly for instant results — no slow AppleScript round-trips.
 
@@ -35,8 +35,8 @@ System Settings → Privacy & Security → Full Disk Access:
 ## Installation
 
 ```bash
-git clone https://github.com/captainmark23/macos-mcp.git
-cd macos-mcp
+git clone https://github.com/captainmark23/mac-apps-mcp.git
+cd mac-apps-mcp
 npm install
 npm run build
 ```
@@ -48,9 +48,9 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 ```json
 {
   "mcpServers": {
-    "macos-mcp": {
+    "mac-apps-mcp": {
       "command": "node",
-      "args": ["/path/to/macos-mcp/build/index.js"],
+      "args": ["/path/to/mac-apps-mcp/build/index.js"],
       "env": {
         "MACOS_MCP_CALENDARS": "My Calendar,Shared Calendar",
         "MACOS_MCP_MAIL_ACCOUNT": "MyAccount"
@@ -80,7 +80,7 @@ To disable all write operations (send, reply, forward, create, delete, etc.):
   "mcpServers": {
     "macos": {
       "command": "npx",
-      "args": ["macos-mcp-server"],
+      "args": ["mac-apps-mcp-server"],
       "env": {
         "MACOS_MCP_READONLY": "true"
       }
@@ -101,7 +101,7 @@ To require explicit confirmation before destructive actions (sending email, dele
   "mcpServers": {
     "macos": {
       "command": "npx",
-      "args": ["macos-mcp-server"],
+      "args": ["mac-apps-mcp-server"],
       "env": {
         "MACOS_MCP_CONFIRM_DESTRUCTIVE": "true"
       }

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# Setting up macos-mcp
+# Setting up mac-apps-mcp
 
 This connects Claude Desktop to your Apple Mail, Calendar, and Reminders so Claude can read your schedule, check your emails, manage reminders, and more.
 
@@ -36,8 +36,8 @@ In Terminal, run:
 
 ```bash
 cd ~
-git clone https://github.com/captainmark23/macos-mcp.git
-cd macos-mcp
+git clone https://github.com/captainmark23/mac-apps-mcp.git
+cd mac-apps-mcp
 npm install
 npm run build
 ```
@@ -69,10 +69,10 @@ Claude Desktop needs permission to read your Mail, Calendar, and Reminders datab
 ```json
 {
   "mcpServers": {
-    "macos-mcp": {
+    "mac-apps-mcp": {
       "command": "node",
       "args": [
-        "/Users/YOUR_USERNAME/macos-mcp/build/index.js"
+        "/Users/YOUR_USERNAME/mac-apps-mcp/build/index.js"
       ],
       "env": {
         "MACOS_MCP_CALENDARS": "Calendar1,Calendar2",
@@ -95,7 +95,7 @@ Claude Desktop needs permission to read your Mail, Calendar, and Reminders datab
 
 ## Step 5: Restart Claude Desktop
 
-Quit Claude Desktop completely (Cmd+Q) and reopen it. The macos-mcp tools should now be available.
+Quit Claude Desktop completely (Cmd+Q) and reopen it. The mac-apps-mcp tools should now be available.
 
 ## Step 6: Test it
 
@@ -134,7 +134,7 @@ After that, you can search with: "Search my emails for invoice from Amazon"
 When updates are available:
 
 ```bash
-cd ~/macos-mcp
+cd ~/mac-apps-mcp
 git pull
 npm install
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "macos-mcp-server",
+  "name": "mac-apps-mcp-server",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "macos-mcp-server",
+      "name": "mac-apps-mcp-server",
       "version": "0.2.0",
       "license": "MIT",
       "os": [
@@ -16,7 +16,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "macos-mcp-server": "build/index.js"
+        "mac-apps-mcp-server": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "macos-mcp-server",
+  "name": "mac-apps-mcp-server",
   "version": "0.2.0",
   "description": "MCP server for macOS — Apple Mail, Calendar, and Reminders via Claude",
   "type": "module",
   "main": "build/index.js",
   "bin": {
-    "macos-mcp-server": "build/index.js"
+    "mac-apps-mcp-server": "build/index.js"
   },
   "files": [
     "build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function log(message: string): void {
 // ─── Server Setup ───────────────────────────────────────────────
 
 const server = new McpServer({
-  name: "macos-mcp-server",
+  name: "mac-apps-mcp-server",
   version: "0.2.0",
 });
 


### PR DESCRIPTION
## Summary\n\nRenames public-facing references from `macos-mcp` to `mac-apps-mcp` to avoid confusion with [CursorTouch/MacOS-MCP](https://github.com/CursorTouch/MacOS-MCP) (OS-level accessibility control). This project controls specific Apple apps via native scripting interfaces.\n\n### Updated\n- `package.json` / `package-lock.json` — name + bin: `macos-mcp-server` → `mac-apps-mcp-server`\n- `src/index.ts` — MCP server name\n- `README.md` — title, clone URL, config examples, npx commands\n- `SETUP.md` — title, clone URL, config examples, directory paths\n- `.github/ISSUE_TEMPLATE/bug_report.md` — server name references\n\n### Intentionally unchanged (backward compatibility)\n- `~/.macos-mcp/` data directory (FTS index, logs)\n- `macos-mcp-smtp` keychain service\n- `MACOS_MCP_*` env var prefix\n- Temp file prefixes\n\nRefs #44\n\nhttps://claude.ai/code/session_01QgR7PeYc3xVSYNVEvzATSe