### PR TITLE
fix(mail): make confirm-destructive warning match outputSchema

### DIFF
--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -962,6 +962,17 @@ describe("needsConfirmation", () => {
     assert.ok(result!.content[0].text.includes("confirm: true"));
   });
 
+  it("warning structuredContent matches SuccessMessageZ shape", () => {
+    process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
+    const result = needsConfirmation(false, "mail_send", "This will send an email.");
+    assert.ok(result !== null);
+    const sc = result!.structuredContent as { success: boolean; message: string };
+    assert.equal(sc.success, false);
+    assert.equal(typeof sc.message, "string");
+    assert.ok(sc.message.includes("mail_send"));
+    assert.ok(sc.message.includes("confirm: true"));
+  });
+
   it("includes the description in the warning", () => {
     process.env.MACOS_MCP_CONFIRM_DESTRUCTIVE = "true";
     const result = needsConfirmation(false, "test_tool", "This will delete everything.");

--- a/src/shared/mcp-helpers.ts
+++ b/src/shared/mcp-helpers.ts
@@ -140,6 +140,11 @@ export const confirmParam = z.boolean().default(false).describe(
  * Check if a destructive tool should proceed.
  * Returns a warning response if confirmation is required but not provided,
  * or null if the tool should proceed normally.
+ *
+ * The warning shape mirrors SuccessMessageZ (`success`, `message`) so it
+ * validates against the destructive tools' outputSchema. Returning a
+ * differently-shaped object (e.g. `{warning}`) would trip MCP's structured
+ * output validation and surface as `-32602: Output validation error`.
  */
 export function needsConfirmation(
   confirm: boolean,
@@ -148,7 +153,8 @@ export function needsConfirmation(
 ): ReturnType<typeof ok> | null {
   if (!isConfirmDestructive() || confirm) return null;
   return ok({
-    warning: `Action "${toolName}" requires confirmation. ${description} Please check with the user, then call again with confirm: true.`,
+    success: false,
+    message: `Action "${toolName}" requires confirmation. ${description} Please check with the user, then call again with confirm: true.`,
   });
 }
 


### PR DESCRIPTION
## Summary
- When \`MACOS_MCP_CONFIRM_DESTRUCTIVE=true\`, every \`mail_send\`, \`mail_reply\`, \`mail_forward\`, \`calendar_delete_event\`, and \`reminders_delete\` call failed with \`-32602: Output validation error\`. The action was correctly gated, but the gate's response shape was wrong.
- \`needsConfirmation\` returned \`{ warning }\` as \`structuredContent\`, which fails validation against the destructive tools' declared \`outputSchema\` (\`SuccessMessageZ\` / \`SuccessZ\`, both of which require \`success: boolean\`).
- Returning \`{ success: false, message }\` keeps the same intent (a soft warning telling the LLM to ask the user and retry with \`confirm: true\`) and validates under both schemas.

## Repro (before fix)
1. Set \`MACOS_MCP_CONFIRM_DESTRUCTIVE=true\` in the server env.
2. Call \`mail_send\` (any args, with or without \`confirm\`).
3. MCP rejects every response with \`-32602: Output validation error\`. \`mail_create_draft\` works fine since it has no \`needsConfirmation\` guard — that's the diagnostic asymmetry that pointed at this.

## Test plan
- [x] Existing \`needsConfirmation\` tests still pass (5/5).
- [x] New test pins \`structuredContent\` shape (\`success: false\`, \`message: string\`) so the regression can't return — the prior test only asserted on \`content[0].text\`, which is why this slipped past.
- [ ] Smoke-test \`mail_send\` end-to-end with \`MACOS_MCP_CONFIRM_DESTRUCTIVE=true\` against a real Mail.app account.
- [ ] Same smoke for \`mail_reply\`, \`mail_forward\`, \`calendar_delete_event\`, \`reminders_delete\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)